### PR TITLE
Updating formula

### DIFF
--- a/EU4toV2/Source/EU4World/EU4Province.cpp
+++ b/EU4toV2/Source/EU4World/EU4Province.cpp
@@ -264,6 +264,10 @@ EU4Province::EU4Province(shared_ptr<Object> obj)
 	checkBuilding(obj, "fort4");
 	checkBuilding(obj, "fort5");
 	checkBuilding(obj, "fort6");
+	checkBuilding(obj, "fort_15th");
+	checkBuilding(obj, "fort_16th");
+	checkBuilding(obj, "fort_17th");
+	checkBuilding(obj, "fort_18th");
 	checkBuilding(obj, "dock");
 	checkBuilding(obj, "drydock");
 	checkBuilding(obj, "shipyard");
@@ -294,6 +298,140 @@ EU4Province::EU4Province(shared_ptr<Object> obj)
 	checkBuilding(obj, "canal");
 	checkBuilding(obj, "road_network");
 	checkBuilding(obj, "post_office");
+	checkProvModifier(obj, "stora_kopparberget_modifier");
+    checkProvModifier(obj, "center_of_trade_modifier");
+    checkProvModifier(obj, "inland_center_of_trade_modifier");
+    checkProvModifier(obj, "natural_harbor");
+	checkProvModifier(obj, "cerro_rico_modifier");
+    checkProvModifier(obj, "spice_islands_modifier");
+    checkProvModifier(obj, "skanemarket");
+    checkProvModifier(obj, "granary_of_the_mediterranean");
+    checkProvModifier(obj, "ven_murano_glass_industry");
+    checkProvModifier(obj, "diamond_mines_of_golconda_modifier");
+    checkProvModifier(obj, "coffea_arabica_modifier");
+    checkProvModifier(obj, "bookmarket_of_x");
+    checkProvModifier(obj, "grand_bank_fisheries");
+    checkProvModifier(obj, "diamond_district");
+    checkProvModifier(obj, "perfume_capital");// to add
+    checkProvModifier(obj, "the_staple_port");
+    checkProvModifier(obj, "free_shipping_through_the_sound");
+    checkProvModifier(obj, "bosphorous_sound_toll");
+    checkProvModifier(obj, "sound_toll");
+    checkProvModifier(obj, "jingdezhen_kilns");
+    checkProvModifier(obj, "trade_post_modifier");
+    checkProvModifier(obj, "river_estuary_modifier");
+    checkProvModifier(obj, "neva_estuary_modifier");
+    checkProvModifier(obj, "daugava_estuary_modifier");
+    checkProvModifier(obj, "neman_estuary_modifier");
+    checkProvModifier(obj, "vistula_estuary_modifier");
+    checkProvModifier(obj, "oder_estuary_modifier");
+    checkProvModifier(obj, "elbe_estuary_modifier");
+    checkProvModifier(obj, "weser_estuary_modifier");
+    checkProvModifier(obj, "ems_estuary_modifier");
+    checkProvModifier(obj, "rhine_estuary_modifier");
+    checkProvModifier(obj, "thames_estuary_modifier");
+    checkProvModifier(obj, "rhone_estuary_modifier");
+    checkProvModifier(obj, "gironde_estuary_modifier");
+    checkProvModifier(obj, "loire_estuary_modifier");
+    checkProvModifier(obj, "seine_estuary_modifier");
+    checkProvModifier(obj, "ebro_estuary_modifier");
+    checkProvModifier(obj, "douro_estuary_modifier");
+    checkProvModifier(obj, "tagus_estuary_modifier");
+    checkProvModifier(obj, "guadiana_estuary_modifier");
+    checkProvModifier(obj, "po_estuary_modifier");
+    checkProvModifier(obj, "danube_estuary_modifier");
+    checkProvModifier(obj, "dnestr_estuary_modifier");
+    checkProvModifier(obj, "dnieper_estuary_modifier");
+    checkProvModifier(obj, "volga_estuary_modifier");
+    checkProvModifier(obj, "don_estuary_modifier");
+    checkProvModifier(obj, "yangtze_estuary_modifier");
+    checkProvModifier(obj, "huang_he_estuary_modifier");
+    checkProvModifier(obj, "ganges_estuary_modifier");
+    checkProvModifier(obj, "indus_estuary_modifier");
+    checkProvModifier(obj, "euphrates_estuary_modifier");
+    checkProvModifier(obj, "nile_estuary_modifier");
+    checkProvModifier(obj, "gambia_estuary_modifier");
+    checkProvModifier(obj, "pearl_estuary_modifier");
+    checkProvModifier(obj, "parana_estuary_modifier");
+    checkProvModifier(obj, "mekong_estuary_modifier");
+    checkProvModifier(obj, "mississippi_estuary_modifier");
+    checkProvModifier(obj, "rio_grande_estuary_modifier");
+    checkProvModifier(obj, "niger_estuary_modifier");
+    checkProvModifier(obj, "saint_lawrence_estuary_modifier");
+    checkProvModifier(obj, "hudson_estuary_modifier");
+    checkProvModifier(obj, "nelson_eastuary_modifier");
+    checkProvModifier(obj, "godavari_estuary_modifier");
+    checkProvModifier(obj, "krodavari_estuary_modifier");
+    checkProvModifier(obj, "krishna_estuary_modifier");
+    checkProvModifier(obj, "kura_estuary_modifier");
+    checkProvModifier(obj, "mangaeza_estuary_modifier");
+    checkProvModifier(obj, "columbia_estuary_modifier");
+    checkProvModifier(obj, "delaware_estuary_modifier");
+    checkProvModifier(obj, "james_estuary_modifier");
+    checkProvModifier(obj, "santee_estuary_modifier");
+    checkProvModifier(obj, "guayas_estuary_modifier");
+    checkProvModifier(obj, "senegal_estuary_modifier");
+    checkProvModifier(obj, "zambezi_estuary_modifier");
+    checkProvModifier(obj, "red_river_estuary_modifier");
+    checkProvModifier(obj, "irrawaddy_estuary_modifier");
+    checkProvModifier(obj, "kongo_estuary_modifier");
+    checkProvModifier(obj, "public_works_of_cairo");
+    checkProvModifier(obj, "port_to_the_new_world");
+    checkProvModifier(obj, "the_tower_or_belem");
+    checkProvModifier(obj, "merchant_council_of_sakai");
+    checkProvModifier(obj, "azuchi_castle");
+    checkProvModifier(obj, "ara_sindicat_remenca");
+    checkProvModifier(obj, "kni_martinengo");
+    checkProvModifier(obj, "kni_valetta");
+    checkProvModifier(obj, "mousquetaires_du_roi");
+    checkProvModifier(obj, "bah_bidar_fort");
+    checkProvModifier(obj, "guj_walls_of_ahmedabad");
+    checkProvModifier(obj, "guj_champaner");
+    checkProvModifier(obj, "mer_kumbalgarh");
+    checkProvModifier(obj, "jnp_jaunpur_qila");
+    checkProvModifier(obj, "kbo_gazargamu");
+    checkProvModifier(obj, "venice_ghetto");
+    checkProvModifier(obj, "fortezza_di_sant_andrea");
+    checkProvModifier(obj, "ven_ministers_of_waterways");
+    checkProvModifier(obj, "ven_black_gondolas");
+    checkProvModifier(obj, "ned_house_of_elzevir");
+    checkProvModifier(obj, "hab_schwaz_mine");
+    checkProvModifier(obj, "pru_unification_of_berlin");
+    checkProvModifier(obj, "nor_bohus_fortress");
+    checkProvModifier(obj, "nor_kongsberg_mine");
+    checkProvModifier(obj, "dansborg_factory");
+    checkProvModifier(obj, "city_of_the_kings");
+    checkProvModifier(obj, "red_fort");
+    checkProvModifier(obj, "dhimmi_residence");
+    checkProvModifier(obj, "last_of_the_mahican");
+    checkProvModifier(obj, "bng_delta_reclaimed");
+    checkProvModifier(obj, "bng_port_of_calcutta");
+    checkProvModifier(obj, "mca_salt_mines_of_zipaquira");
+    checkProvModifier(obj, "hub_of_orinoco_trade");
+    checkProvModifier(obj, "kizilirmak_estuary_modifier");
+    checkProvModifier(obj, "menderes_estuary_modifier");
+    checkProvModifier(obj, "el_dorado_mod");
+    checkProvModifier(obj, "sce_life_water");
+    checkProvModifier(obj, "sce_cibola_silver");
+    checkProvModifier(obj, "sce_sierradelaplata_quartz");
+    checkProvModifier(obj, "sce_golden_cups");
+    checkProvModifier(obj, "sce_norumbega_abandoned");
+    checkProvModifier(obj, "sce_saguenay_abandoned");
+    checkProvModifier(obj, "sce_city_of_caesars");
+    checkProvModifier(obj, "sce_quivira");
+    checkProvModifier(obj, "birthplace_of_the_renaissance");
+    checkProvModifier(obj, "birthplace_of_the_new_world");
+    checkProvModifier(obj, "birthplace_of_printing_press");
+    checkProvModifier(obj, "birthplace_of_global_trade");
+    checkProvModifier(obj, "birthplace_of_manufactories");
+    checkProvModifier(obj, "birthplace_of_enlightenment");
+    checkProvModifier(obj, "growth_of_global_trade");
+    checkProvModifier(obj, "slave_entrepot");
+    checkProvModifier(obj, "major_slave_market");
+    checkProvModifier(obj, "the_will_of_tano");
+    checkProvModifier(obj, "the_whim_of_anansi");
+    checkProvModifier(obj, "trading_post_modifier");
+    checkTerritory(obj);
 
 	buildPopRatios();
 }
@@ -372,6 +510,13 @@ bool EU4Province::hasBuilding(string building) const
 }
 
 
+bool EU4Province::hasProvModifier(string provmodifier) const
+{
+	const int num = provModifiers.count(provmodifier);	// the number of this building
+	return (num > 0);
+}
+
+
 vector<std::shared_ptr<EU4::Country>> EU4Province::getCores(const map<string, std::shared_ptr<EU4::Country>>& countries) const
 {
 	std::vector<std::shared_ptr<EU4::Country>> coreOwners;	// the core holders
@@ -415,6 +560,29 @@ double EU4Province::getCulturePercent(string culture)
 }
 
 
+void EU4Province::checkProvModifier(const shared_ptr<Object> provinceObj, string modifierToFind)
+{
+    vector<shared_ptr<Object>> modifierObj;    // the object holding the modifiers
+    modifierObj = provinceObj->getValue("modifier");
+    if ((modifierObj.size() > 0))
+    {
+        vector<shared_ptr<Object>> modifierObjs = modifierObj[0]->getLeaves();
+        for (auto i : modifierObjs)
+        {
+            //LOG(LogLevel::Info) << "Leaf: " << i->getLeaf();
+
+            if (i->getLeaf() == modifierToFind)
+            {
+                std::cout << std::endl << "Modifier Found" << std::endl;
+                LOG(LogLevel::Info) << "Modifier Found";
+                provModifiers[modifierToFind] = true;
+                break;
+            }
+        }
+    }
+}
+
+
 void EU4Province::checkBuilding(const shared_ptr<Object> provinceObj, string building)
 {
 	vector<shared_ptr<Object>> buildingObj;	// the object holding the building
@@ -422,6 +590,18 @@ void EU4Province::checkBuilding(const shared_ptr<Object> provinceObj, string bui
 	if ((buildingObj.size() > 0) && (buildingObj[0]->getLeaf() == "yes"))
 	{
 		buildings[building] = true;
+	}
+}
+
+
+void EU4Province::checkTerritory(const shared_ptr<Object> provinceObj)
+{
+	
+	vector<shared_ptr<Object>> TerritoryObjs;			// the object holding the base tax
+	TerritoryObjs = provinceObj->getValue("territorial_core");
+	if ((TerritoryObjs.size() > 0))
+	{	
+            territory = true;
 	}
 }
 
@@ -618,13 +798,6 @@ void EU4Province::determineProvinceWeight()
 		LOG(LogLevel::Error) << "Error in building weight vector: " << e.what();
 	}
 
-	// Check tag, ex. TIB has goods_produced +0.05
-	// This needs to be hard coded unless there's some other way of figuring out modded national ambitions/ideas
-	if (this->getOwnerString() == "TIB")
-	{
-		goods_produced_perc_mod += 0.05;
-	}
-
 	double goods_produced = (baseProd * 0.2) + manu_gp_mod + goods_produced_perc_mod + 0.03;
 
 	// idea effects
@@ -640,15 +813,16 @@ void EU4Province::determineProvinceWeight()
 	// manpower
 	manpower_weight *= 25;
 	manpower_weight += manpower_modifier;
-	manpower_weight *= ((1 + manpower_modifier) / 25); // should work now as intended
+	manpower_weight *= ((1 + manpower_eff) / 25); // should work now as intended
 
 	//LOG(LogLevel::Info) << "Manpower Weight: " << manpower_weight;
 
-	double total_tx = (baseTax + building_tx_income) * (1.0 + building_tx_eff + 0.15);
-	double production_eff_tech = 0.5; // used to be 1.0
+	double total_tx = (baseTax + building_tx_income) * (1.5 + building_tx_eff + 0.1);
+	double production_eff_tech = 0.2; // used to be 1.0
 
 	double total_trade_value = ((getTradeGoodPrice() * goods_produced) + trade_value) * (1 + trade_value_eff);
-	double production_income = total_trade_value * (1 + production_eff_tech + production_eff);
+	double production_income = total_trade_value * (1.8 + production_eff_tech + production_eff);
+	//the bonus 0.4 is supposed to show trade income from trade goods as there is no better way to show it atm, but it still has to be shown to show superiority of base production later on
 	//LOG(LogLevel::Info) << "province name: " << this->getProvName() 
 	//	<< " trade good: " << tradeGoods 
 	//	<< " Price: " << getTradeGoodPrice() 
@@ -659,9 +833,11 @@ void EU4Province::determineProvinceWeight()
 	//	<< " production eff: " << production_eff 
 	//	<< " Production: " << production_income;
 
-	total_tx *= 1.5;
+	total_tx *= 1;
 	manpower_weight *= 1;
-	production_income *= 1.5;
+	production_income *= 1;
+	// dev modifier
+	dev_modifier *= ( baseTax + baseProd + manpower );			   
 
 	provBuildingWeight	= building_weight;
 	provTaxIncome			= total_tx;
@@ -670,11 +846,72 @@ void EU4Province::determineProvinceWeight()
 	provTradeGoodWeight	= trade_goods_weight;
 	provDevModifier	= dev_modifier;
 	
-	// dev modifier
-	dev_modifier *= ( baseTax + baseProd + manpower );
+	if (baseTax + baseProd + manpower >= 10)
+	{	
+		building_weight += 1;
+	
+		if (baseTax + baseProd + manpower >= 20)
+		{	
+			building_weight += 2;
+	
+			if (baseTax + baseProd + manpower >= 30)
+			{	
+				building_weight += 4;
+	
+				if (baseTax + baseProd + manpower >= 40)
+				{	
+					building_weight += 6;
+	
+					if (baseTax + baseProd + manpower >= 50)
+					{	
+						building_weight += 9;
+	
+						if (baseTax + baseProd + manpower >= 60)
+						{	
+							building_weight += 12;
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	if (baseTax + baseProd + manpower >= 15)
+	{	
+		building_weight += 1;
+	
+		if (baseTax + baseProd + manpower >= 25)
+		{	
+			building_weight += 2;
+	
+			if (baseTax + baseProd + manpower >= 35)
+			{	
+				building_weight += 4;
+	
+				if (baseTax + baseProd + manpower >= 45)
+				{	
+					building_weight += 6;
+	
+					if (baseTax + baseProd + manpower >= 55)
+					{	
+						building_weight += 9;
+	
+						if (baseTax + baseProd + manpower >= 65)
+						{	
+							building_weight += 12;
+						}
+					}
+				}
+			}
+		}
+	}
 
 	totalWeight = building_weight + dev_modifier + ( manpower_weight + production_income + total_tx );
 	//i would change dev effect to 1, but your choice
+	if (territory == true)
+	{
+		totalWeight *= 0.5;
+	}
 	if (owner == NULL)
 	{
 		totalWeight = 0;
@@ -701,6 +938,8 @@ double EU4Province::getTradeGoodPrice() const
 {
 	// Trade goods
 	/*
+	Trade good prices based on this : 
+	https://forum.paradoxplaza.com/forum/index.php?threads/analysis-of-trade-good-tiers-and-prices.914875/#post-23767415
 	chinaware
 	grain
 	fish
@@ -724,45 +963,50 @@ double EU4Province::getTradeGoodPrice() const
 	silk
 	dyes
 	tropical_wood
+	incense
+	glass
+	livestock
+	gems
+	paper
 	*/
 	//LOG(LogLevel::Info) << "Trade Goods Price";
 	double tradeGoodsPrice = 0;
 
 	if (tradeGoods == "chinaware")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.04;
 	}
 	else if (tradeGoods == "grain")
 	{
-		tradeGoodsPrice = 2;
+		tradeGoodsPrice = 2.03;
 	}
 	else if (tradeGoods == "fish")
 	{
-		tradeGoodsPrice = 2.5;
+		tradeGoodsPrice = 2.11;
 	}
 	else if (tradeGoods == "tabacco")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.84;
 	}
 	else if (tradeGoods == "iron")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.74;
 	}
 	else if (tradeGoods == "copper")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.79;
 	}
 	else if (tradeGoods == "cloth")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.62;
 	}
 	else if (tradeGoods == "slaves")
 	{
-		tradeGoodsPrice = 2;
+		tradeGoodsPrice = 2.68;
 	}
 	else if (tradeGoods == "salt")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.24;
 	}
 	else if (tradeGoods == "gold")
 	{
@@ -770,59 +1014,79 @@ double EU4Province::getTradeGoodPrice() const
 	}
 	else if (tradeGoods == "fur")
 	{
-		tradeGoodsPrice = 2;
+		tradeGoodsPrice = 3.14;
 	}
 	else if (tradeGoods == "sugar")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.71;
 	}
 	else if (tradeGoods == "naval_supplies")
 	{
-		tradeGoodsPrice = 2;
+		tradeGoodsPrice = 2.35;
 	}
 	else if (tradeGoods == "tea")
 	{
-		tradeGoodsPrice = 2;
+		tradeGoodsPrice = 2.68;
 	}
 	else if (tradeGoods == "coffee")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 2.97;
 	}
 	else if (tradeGoods == "spices")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.68;
 	}
 	else if (tradeGoods == "wine")
 	{
-		tradeGoodsPrice = 2.5;
+		tradeGoodsPrice = 2.75;
 	}
 	else if (tradeGoods == "cocoa")
 	{
-		tradeGoodsPrice = 4;
+		tradeGoodsPrice = 4.39;
 	}
 	else if (tradeGoods == "ivory")
 	{
-		tradeGoodsPrice = 4;
+		tradeGoodsPrice = 4.19;
 	}
 	else if (tradeGoods == "wool")
 	{
-		tradeGoodsPrice = 2.5;
+		tradeGoodsPrice = 2.7;
 	}
 	else if (tradeGoods == "cotton")
 	{
-		tradeGoodsPrice = 3;
+		tradeGoodsPrice = 3.56;
 	}
 	else if (tradeGoods == "dyes")
 	{
-		tradeGoodsPrice = 4;
+		tradeGoodsPrice = 4.36;
 	}
 	else if (tradeGoods == "tropical_wood")
 	{
-		tradeGoodsPrice = 2;
+		tradeGoodsPrice = 2.52;
 	}
 	else if (tradeGoods == "silk")
 	{
-		tradeGoodsPrice = 4;
+		tradeGoodsPrice = 4.47;
+	}
+	else if (tradeGoods == "incense")
+	{
+		tradeGoodsPrice = 2.74;
+	}
+	else if (tradeGoods == "livestock")
+	{
+		tradeGoodsPrice = 2.94;
+	}
+	else if (tradeGoods == "glass")
+	{
+		tradeGoodsPrice = 3.23;
+	}
+	else if (tradeGoods == "gems")
+	{
+		tradeGoodsPrice = 3.67;
+	}
+	else if (tradeGoods == "paper")
+	{
+		tradeGoodsPrice = 4.42;
 	}
 	else
 	{
@@ -981,7 +1245,7 @@ vector<double> EU4Province::getProvBuildingWeight() const
 	double trade_value					= 0.0;
 	double trade_value_eff				= 0.0;
 	double trade_power_eff				= 0.0;
-	double dev_modifier				= 0.0;
+	double dev_modifier				= 1.45; // representing forcelimit and trade power prov has from dev
 
 	// unique buildings
 	/*
@@ -1600,9 +1864,9 @@ vector<double> EU4Province::getProvBuildingWeight() const
 	}*/
 
 	
-if (hasBuilding("university"))
+	if (hasBuilding("university"))
     {
-        building_weight += 6;
+        building_weight += 3;
     }
 
     // manfacturies building
@@ -1657,7 +1921,22 @@ if (hasBuilding("university"))
     if (hasBuilding("fort4"))
     {
         building_weight += 16;
-
+    }
+    if (hasBuilding("fort_15th"))
+    {
+        building_weight += 4;
+    }
+    if (hasBuilding("fort_16th"))
+    {
+        building_weight += 8;
+    }
+    if (hasBuilding("fort_17th"))
+    {
+        building_weight += 12;
+    }
+    if (hasBuilding("fort_18th"))
+    {
+        building_weight += 16;
     }
     if (hasBuilding("dock"))
     {
@@ -1671,12 +1950,12 @@ if (hasBuilding("university"))
 
     if (hasBuilding("shipyard"))
     {
-        dev_modifier += 0.1;
+        dev_modifier += 0.075;
     }
 
     if (hasBuilding("grand_shipyard"))
     {
-        dev_modifier += 0.2;
+        dev_modifier += 0.15;
     }
 
     if (hasBuilding("temple"))
@@ -1744,35 +2023,440 @@ if (hasBuilding("university"))
     {
         dev_modifier += 0.15;
     }
-
-    if (hasBuilding("center_of_trade"))
+    if (hasProvModifier("center_of_trade_modifier"))
     {
         building_weight += 24;
     }
 
-    if (hasBuilding("inland_center_of_trade"))
+    if (hasProvModifier("inland_center_of_trade_modifier"))
     {
         building_weight += 12;
     }
 
-    if (hasBuilding("natural_harbor"))
+    if (hasProvModifier("natural_harbor"))
     {
         building_weight += 15;
     }
 
-    if (hasBuilding("stora_kopparberget_modifier"))
+    if (hasProvModifier("stora_kopparberget_modifier"))
     {
         manu_gp_mod = 5.0;
     }
 
-    if (hasBuilding("cerro_rico_modifier"))
+    if (hasProvModifier("cerro_rico_modifier"))
     {
         manu_gp_mod = 3.0;
     }
 
-    if (hasBuilding("spice_islands_modifier"))
+    if (hasProvModifier("spice_islands_modifier"))
     {
         manu_gp_mod = 3.0;
+    }
+
+    if (hasProvModifier("skanemarket"))
+    {
+        manu_gp_mod = 1.5;
+    }
+
+    if (hasProvModifier("granary_of_the_mediterranean"))
+    {
+        manu_gp_mod = 2.0;
+    }
+
+    if (hasProvModifier("ven_murano_glass_industry"))
+    {
+        manu_gp_mod = 2.0;
+    }
+
+    if (hasProvModifier("diamond_mines_of_golconda_modifier"))
+    {
+        manu_gp_mod = 4.0;
+    }
+
+    if (hasProvModifier("coffea_arabica_modifier"))
+    {
+        manu_gp_mod = 3.0;
+    }
+
+    if (hasProvModifier("bookmarket_of_x"))
+    {
+        manu_gp_mod = 1.0;
+    }
+
+    if (hasProvModifier("grand_bank_fisheries"))
+    {
+        manu_gp_mod = 2.0;
+    }
+
+    if (hasProvModifier("diamond_district"))
+    {
+        manu_gp_mod = 0.5;
+	trade_value_eff = 0.15;
+    }
+
+    if (hasProvModifier("perfume_capital"))
+    {
+        manu_gp_mod = 0.5;
+	trade_value_eff = 0.15;
+    }
+
+    if (hasProvModifier("jingdezhen_kilns"))
+    {
+        manu_gp_mod = 2.5;
+    }
+
+    if (hasProvModifier("the_staple_port"))
+    {
+        dev_modifier += 0.0375;
+        building_tx_eff += 0.50;
+    }
+
+    if (hasProvModifier("free_shipping_through_the_sound"))
+    {
+        dev_modifier += 0.0375;
+        building_weight += 11.25;
+    }
+
+    if (hasProvModifier("bosphorous_sound_toll"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("sound_toll"))
+    {
+        building_weight += 15;
+    }
+
+    if (hasProvModifier("trade_post_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("ganges_estuary_modifier"))
+    {
+        building_weight += 3.75;
+    }
+
+    if (hasProvModifier("nile_estuary_modifier"))
+    {
+        building_weight += 3.75;
+    }
+
+    if (hasProvModifier("irrawaddy_estuary_modifier"))
+    {
+        building_weight += 3.75;
+    }
+
+    if (hasProvModifier("river_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("neva_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("daugava_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("neman_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("vistula_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("oder_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("elbe_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("weser_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("ems_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("rhine_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("thames_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("rhone_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("gironde_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("loire_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("seine_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("ebro_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("douro_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("tagus_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("guadiana_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("po_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("danube_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("dnestr_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("dnieper_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("volga_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("don_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("yangtze_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("huang_he_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("indus_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("euphrates_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("gambia_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("pearl_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("parana_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("mekong_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("mississippi_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("rio_grande_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("niger_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("saint_lawrence_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("hudson_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("nelson_eastuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("godavari_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("krodavari_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("krishna_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("kura_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("mangaeza_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("columbia_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("delaware_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("james_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("santee_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("guayas_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("senegal_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("zambezi_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("red_river_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("kongo_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("kizilirmak_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("menderes_estuary_modifier"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("trading_post_modifier"))
+    {
+        building_weight += 0.75;
+        dev_modifier += 0.03;
+        trade_value += 0.5;
+    }
+
+    if (hasProvModifier("birthplace_of_the_renaissance"))
+    {
+        building_weight += 3;
+    }
+
+    if (hasProvModifier("birthplace_of_the_new_world"))
+    {
+        building_weight += 7.5;
+    }
+
+    if (hasProvModifier("birthplace_of_printing_press"))
+    {
+        building_weight += 1.5;
+    }
+
+    if (hasProvModifier("birthplace_of_global_trade"))
+    {
+        dev_modifier += 0.06;
+    }
+
+    if (hasProvModifier("birthplace_of_manufactories"))
+    {
+        manu_gp_mod += 0.5;
+    }
+
+    if (hasProvModifier("birthplace_of_enlightenment"))
+    {
+        building_weight += 1.5;
     }
 
 	std::vector<double> provBuildingWeightVec;

--- a/EU4toV2/Source/EU4World/EU4Province.h
+++ b/EU4toV2/Source/EU4World/EU4Province.h
@@ -62,15 +62,20 @@ class EU4Province
 		void						removeCore(string tag);
 		void						determineProvinceWeight();
 
+							
+
 		bool						wasColonised() const;
 		bool						wasInfidelConquest() const;
 		bool						hasBuilding(string building) const;
+													   
 		std::vector<std::shared_ptr<EU4::Country>>	getCores(const std::map<std::string, std::shared_ptr<EU4::Country>>& countries) const;
 		date						getLastPossessedDate(string tag) const;
 		double getCulturePercent(string culture);
 
 		int						getNum()					const { return num; }
 		double					getBaseTax()			const { return baseTax; }
+													   
+													   
 		string					getOwnerString()		const { return ownerString; }
 		std::shared_ptr<EU4::Country> getOwner() const { return owner; }
 		bool						getInHRE()				const { return inHRE; }
@@ -96,7 +101,9 @@ class EU4Province
 
 	private:
 		void	checkBuilding(const shared_ptr<Object> provinceObj, string building);
-		void	buildPopRatios();
+		void	checkProvModifier(const shared_ptr<Object> provinceObj, string modifierToFind);
+		void	checkTerritory(const shared_ptr<Object> provinceObj);
+	void	buildPopRatios();
 		void	decayPopRatios(date oldDate, date newDate, EU4PopRatio& currentPop);
 
 		vector<double>	getProvBuildingWeight()	const;
@@ -120,6 +127,8 @@ class EU4Province
 		vector< pair<date, string> >	cultureHistory;		// the history of the cultural changes of this province
 		vector<EU4PopRatio>				popRatios;				// the population ratios of this province
 		map<string, bool>					buildings;				// the buildings in this province
+		map<string, bool>					provModifiers;				// the buildings in this province
+		bool							territory;				// the buildings in this province
 
 		string								tradeGoods;
 		int									numV2Provs;


### PR DESCRIPTION
-Increasing detail in pop conversion via prov modifiers and territories
-Updating forts (forgot it at some point)
-Buffing tall nations (improving dev costs far more at high dev)
-Nerf buildings a bit (tax and prod changes in formula)
-Buffing/Adjusting development via setting it to same standard as buildings
-Add new trade goods
-Adjust trade good prices to be less late game dependent

To be done:
-Add other new trade goods
-Buff development a bit more possibly (balance between money and monarch points is hard to set right)
-Make territories potentially a bit less punishing (66% instead of 50%)
-Remove pop ratio effects from formula if pop conversion is used
-Make final culture conversion (final if several) have a base effect of 5% on all culture conversions (to make culture conversion not useless late game) if pop conversion is used (u should rly consider this in general)
-Remove continental effects on literacy if pop conversion is used
